### PR TITLE
unpack: cleanup by alot, remove >/dev/null and verbose flags

### DIFF
--- a/unpack
+++ b/unpack
@@ -2,70 +2,38 @@
 # unpack - unarchive archive files
 # this file in public domain
 
-usage()
+die()
 {
-	echo "usage: unpack file [destdir]" >&2
+	printf "%s\n" "$*" >&2
 	exit 1
 }
 
+crun()
+{
+	command -v "$1" 2>&1 >/dev/null ||
+		die "unpack: utility $1 is not installed"
+
+	"$@" || die "failed to extract"
+}
+
 case "$#" in
-(1) set -- "$1" "$PWD" ;;
-(2)                    ;;
-(*) usage              ;;
+	(1) set -- "$1" "$PWD" ;;
+	(2) ;;
+	(*) die "usage: unpack file [destdir]" ;;
 esac
 
-if [ ! -f "$1" ]
-then
-	printf "unpack: %s: not a regular file\n" "$1"
-	exit 1
-fi
+! [ -e "$1" ] && die "unpack: $1: not a valid file"
+! [ -d "$2" ] && die "unpack: $2: not a valid directory"
 
-if [ ! -d "$2" ]
-then
-	printf "unpack: %s: not a regular file\n" "$2"
-	exit 1
-fi
-
-case "$(file -ib -- "$1" | cut -d';' -f1 | cut -d'/' -f2)" in
-gzip|x-gzip)
-	tar xzvf "$1" -C "$2" >/dev/null || {
-	echo "Package can not be extracted, try to install 'tar'" &&
-	exit 1 ; }
-	;;
-bzip2|x-bzip2)
-	tar xjvf "$1" -C "$2" >/dev/null || {
-	echo "Package can not be extracted, try to install 'tar'" &&
-	exit 1 ; }
-	;;
-tar|x-tar)
-	tar xvf "$1" -C "$2" >/dev/null || {
-	echo "Package can not be extracted, try to install 'tar'" &&
-	exit 1 ; }
-	;;
-zip)
-	unzip -d "$2" -- "$1" >/dev/null || {
-	echo "Package can not be extracted, try to install 'unzip'" &&
-	exit 1 ; }
-	;;
-x-rar)
-	unrar x "$1" "$2" >/dev/null || {
-	echo "Package can not be extracted, try to install 'unrar'" &&
-	exit 1 ; }
-	;;
-x-7z-compressed)
-	7z x -o"$2" "$1" >/dev/null || {
-	echo "Package can not be extracted, try to install '7-zip'" &&
-	exit 1 ; }
-	;;
-x-xz)
-	xzcat "$1" | tar xvf - -C "$2" >/dev/null || {
-	echo "Package can not be extracted, try to install 'xz'" &&
-	exit 1 ; }
-	;;
-*)
-	printf "unpack: %s: not an archive file\n" "$1"
-	exit 1
-	;;
+case "${1##*.}" in
+tgz|gz)  crun tar xzf "$1" -C "$2" ;;
+txz|xz)  crun tar xJf "$1" -C "$2" ;;
+tbz|bz2) crun tar xjf "$1" -C "$2" ;;
+tar)     crun tar xf  "$1" -C "$2" ;;
+zip)     crun unzip -d "$2" "$1"   ;;
+rar)     crun unrar x "$1" "$2"    ;;
+7z)      crun 7z x -o "$2" "$1"    ;;
+*) die "unpack: $1: not a supported archive file\n" ;;
 esac
 
 printf "extracted %s to %s\n" "$1" "$2"


### PR DESCRIPTION
fmutils by default will have the verbose flags set on the extraction utility but pass its output to >/dev/null.. makes someone wonder.

i've also cleaned up tons of duplicate lines of code.

i have implemented a `die()` function that prints to stderr and exits. also shortened the if statements to a simpler way. implemeneted a `crun()` function that checks if the first argument, aka the tool; exists and dies if not the case.

@hasanpasha would like to see your opinion